### PR TITLE
Fix various bugs causes by #3

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -134,9 +134,14 @@ function inputNDJSON() {
   return {dataset}
 }
 
+function inputNull() {
+  return {}
+}
+
 const INPUTTERS = {
   json: inputJSON,
   ndjson: inputNDJSON,
+  null: inputNull,
 }
 
 async function* runQuery() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /* eslint-disable id-length, no-process-exit */
-require("regenerator-runtime/runtime")
+require('regenerator-runtime/runtime')
 const meow = require('meow')
-const { parse, evaluate } = require('groq-js')
+const {parse, evaluate} = require('groq-js')
 const getStdin = require('get-stdin')
 const chalk = require('chalk')
 const ndjson = require('ndjson')
@@ -70,63 +70,61 @@ Examples
   }
 )
 
-function handleError (error) {
+function handleError(error) {
   console.error(chalk.red(error))
   process.emit('SIGINT')
 }
 
 function validateChoice(title, input, choices) {
   if (!choices.includes(input)) {
-    throw Error(chalk.yellow(`Unknown ${title}: ${input}. Valid choices are: ${choices.join(', ')}.`))
+    throw Error(
+      chalk.yellow(`Unknown ${title}: ${input}. Valid choices are: ${choices.join(', ')}.`)
+    )
   }
 }
 
-function check ({ query, inputFormat, outputFormat }) {
+function check({query, inputFormat, outputFormat}) {
   if (!query) {
-    throw Error(
-      chalk.yellow(
-        'You must add a query. To learn more, run\n\n  $ groq --help'
-      )
-    )
+    throw Error(chalk.yellow('You must add a query. To learn more, run\n\n  $ groq --help'))
   }
 
-  validateChoice("input format", inputFormat, ['json', 'ndjson', 'null'])
-  validateChoice("output format", outputFormat, ['json', 'ndjson', 'pretty'])
+  validateChoice('input format', inputFormat, ['json', 'ndjson', 'null'])
+  validateChoice('output format', outputFormat, ['json', 'ndjson', 'pretty'])
 
   return true
 }
 
 async function* outputJSON(result) {
   yield JSON.stringify(await result.get())
-  yield "\n"
+  yield '\n'
 }
 
 async function* outputPrettyJSON(result) {
   yield colorizeJson(await result.get())
-  yield "\n"
+  yield '\n'
 }
 
 async function* outputNDJSON(result) {
   if (result.getType() == 'array') {
     for await (const value of result) {
       yield JSON.stringify(await value.get())
-      yield "\n"
+      yield '\n'
     }
   } else {
     yield JSON.stringify(await result.get())
-    yield "\n"
+    yield '\n'
   }
 }
 
 const OUTPUTTERS = {
   json: outputJSON,
   pretty: outputPrettyJSON,
-  ndjson: outputNDJSON,
+  ndjson: outputNDJSON
 }
 
 async function inputJSON() {
   const input = await getStdin()
-  const dataset = input === "" ? null : JSON.parse(input)
+  const dataset = input === '' ? null : JSON.parse(input)
   return {dataset, root: dataset}
 }
 
@@ -142,13 +140,13 @@ function inputNull() {
 const INPUTTERS = {
   json: inputJSON,
   ndjson: inputNDJSON,
-  null: inputNull,
+  null: inputNull
 }
 
 async function* runQuery() {
-  const { flags, input } = cli
-  const { pretty, ndjson: isNdjson } = flags
-  let { input: inputFormat, output: outputFormat } = flags
+  const {flags, input} = cli
+  const {pretty, ndjson: isNdjson} = flags
+  let {input: inputFormat, output: outputFormat} = flags
 
   const query = input[0]
 
@@ -161,7 +159,7 @@ async function* runQuery() {
     inputFormat = 'ndjson'
   }
 
-  check({ query, inputFormat, outputFormat })
+  check({query, inputFormat, outputFormat})
 
   // Parse query
   const tree = parse(query)

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,10 +17,10 @@ Usage
   ${chalk.grey(`# Remember to alternate quotation marks inside of the query`)}
 
 Options
-  ${chalk.green(`-i, --input   One of: ndjson, json, null`)}
-  ${chalk.green(`-o, --output  One of: ndjson, json, pretty`)}
-  ${chalk.green(`-p, --pretty  Shortcut for --output=pretty`)}
-  ${chalk.green(`-n, --ndjson  Shortcut for --input=ndjson --output=ndjson`)}
+  ${chalk.green(`-i, --input`)}   One of: ndjson, json, null
+  ${chalk.green(`-o, --output`)}  One of: ndjson, json, pretty
+  ${chalk.green(`-p, --pretty`)}  Shortcut for --output=pretty
+  ${chalk.green(`-n, --ndjson`)}  Shortcut for --input=ndjson --output=ndjson
 
 Input formats
   ${chalk.green(`json`)}      Reads a JSON object from stdin.

--- a/src/cli.js
+++ b/src/cli.js
@@ -125,7 +125,8 @@ const OUTPUTTERS = {
 }
 
 async function inputJSON() {
-  const dataset = JSON.parse(await getStdin())
+  const input = await getStdin()
+  const dataset = input === "" ? null : JSON.parse(input)
   return {dataset, root: dataset}
 }
 


### PR DESCRIPTION
Some small issues that turned out wasn't done properly in #3:

- Running `groq 1` in a terminal (without anything on stdin) would crash with "SyntaxError: Invalid JSON". Now if you run `groq QUERY` in the terminal (without piping anything to it) it's equivalent to `--input null`.
- Reduced the amount of green color in --help.
- `--input null` wasn't implemented correctly.