### PR TITLE
Support string output with --pretty

### DIFF
--- a/src/colorizeJson.js
+++ b/src/colorizeJson.js
@@ -11,8 +11,7 @@ const formatters = {
 }
 
 function colorize(input) {
-  const data = typeof input === 'string' ? JSON.parse(input) : input
-  const json = JSON.stringify(data, null, 2)
+  const json = JSON.stringify(input, null, 2)
 
   return tokenize(json)
     .map((token, i, arr) => {


### PR DESCRIPTION
The following command crashed:

```
$ groq '"foo"' --pretty
```

This was caused by the colorize function automatically parsing any
strings as stringified JSON. That might be useful in other projects, but
not for us.